### PR TITLE
Add isAppearing and isHiding methods

### DIFF
--- a/lib/flushbar.dart
+++ b/lib/flushbar.dart
@@ -290,6 +290,16 @@ class Flushbar<T> extends StatefulWidget {
     return _flushbarRoute?.currentStatus == FlushbarStatus.DISMISSED;
   }
 
+  /// Checks if the flushbar is appearing
+  bool isAppearing() {
+    return _flushbarRoute?.currentStatus == FlushbarStatus.IS_APPEARING;
+  }
+
+  /// Checks if the flushbar is hiding
+  bool isHiding() {
+    return _flushbarRoute?.currentStatus == FlushbarStatus.IS_HIDING;
+  }
+
   @override
   State createState() => _FlushbarState<T?>();
 }


### PR DESCRIPTION
In our app, we have a case when we need to show the Flushbar on app state change. Currently, we are executing the logic like this:

```
if (state.isOff && !customFlushbar.isShowing()) {
    customFlushbar.show(context);
} else if (state.isOn && customFlushbar.isShowing()) {
    customFlushbar.dismiss(context);
}
```

However, there are cases when the state could change while the app is running in the background, then we receive multiple state change events at the same time. As a result, the first condition returns `true` until the Flushbar animation ends which means that the `customFlushbar.show(context);` could be triggered multiple times, multiple Flushbars appear on top of each other.

To resolve this, I would like to expose the "isAppearing()" and "isHiding()" methods so we could check both states - whether the Flushbar is showing or the showing animation is ongoing.