### PR TITLE
Fix nullpointer on onStatusChanged & add pedantic analysis and formatting

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -90,12 +90,12 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
-          Flushbar(
-            title: "Hey Ninja",
+          await Flushbar(
+            title: 'Hey Ninja',
             message:
-                "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
+                'Lorem Ipsum is simply dummy text of the printing and typesetting industry',
             duration: Duration(seconds: 3),
-          )..show(context);
+          ).show(context);
         },
         tooltip: 'Increment',
         child: Icon(Icons.add),

--- a/lib/flushbar.dart
+++ b/lib/flushbar.dart
@@ -6,10 +6,10 @@ import 'package:flutter/scheduler.dart';
 
 import 'flushbar_route.dart' as route;
 
-const String FLUSHBAR_ROUTE_NAME = "/flushbarRoute";
+const String FLUSHBAR_ROUTE_NAME = '/flushbarRoute';
 
-typedef void FlushbarStatusCallback(FlushbarStatus? status);
-typedef void OnTap(Flushbar flushbar);
+typedef FlushbarStatusCallback = void Function(FlushbarStatus? status);
+typedef OnTap = void Function(Flushbar flushbar);
 
 /// A highly customizable widget so you can notify your user when you fell like he needs a beautiful explanation.
 class Flushbar<T> extends StatefulWidget {
@@ -57,49 +57,49 @@ class Flushbar<T> extends StatefulWidget {
       double? routeBlur,
       Color? routeColor,
       Form? userInputForm})
-      : this.title = title,
-        this.titleSize = titleSize,
-        this.titleColor = titleColor,
-        this.message = message,
-        this.messageSize = messageSize,
-        this.messageColor = messageColor,
-        this.titleText = titleText,
-        this.messageText = messageText,
-        this.icon = icon,
-        this.shouldIconPulse = shouldIconPulse,
-        this.maxWidth = maxWidth,
-        this.margin = margin,
-        this.padding = padding,
-        this.borderRadius = borderRadius,
-        this.borderColor = borderColor,
-        this.borderWidth = borderWidth,
-        this.backgroundColor = backgroundColor,
-        this.leftBarIndicatorColor = leftBarIndicatorColor,
-        this.boxShadows = boxShadows,
-        this.backgroundGradient = backgroundGradient,
-        this.mainButton = mainButton,
-        this.onTap = onTap,
-        this.duration = duration,
-        this.isDismissible = isDismissible,
-        this.dismissDirection = dismissDirection,
-        this.showProgressIndicator = showProgressIndicator,
-        this.progressIndicatorController = progressIndicatorController,
-        this.progressIndicatorBackgroundColor =
+      : title = title,
+        titleSize = titleSize,
+        titleColor = titleColor,
+        message = message,
+        messageSize = messageSize,
+        messageColor = messageColor,
+        titleText = titleText,
+        messageText = messageText,
+        icon = icon,
+        shouldIconPulse = shouldIconPulse,
+        maxWidth = maxWidth,
+        margin = margin,
+        padding = padding,
+        borderRadius = borderRadius,
+        borderColor = borderColor,
+        borderWidth = borderWidth,
+        backgroundColor = backgroundColor,
+        leftBarIndicatorColor = leftBarIndicatorColor,
+        boxShadows = boxShadows,
+        backgroundGradient = backgroundGradient,
+        mainButton = mainButton,
+        onTap = onTap,
+        duration = duration,
+        isDismissible = isDismissible,
+        dismissDirection = dismissDirection,
+        showProgressIndicator = showProgressIndicator,
+        progressIndicatorController = progressIndicatorController,
+        progressIndicatorBackgroundColor =
             progressIndicatorBackgroundColor,
-        this.progressIndicatorValueColor = progressIndicatorValueColor,
-        this.flushbarPosition = flushbarPosition,
-        this.positionOffset = positionOffset,
-        this.flushbarStyle = flushbarStyle,
-        this.forwardAnimationCurve = forwardAnimationCurve,
-        this.reverseAnimationCurve = reverseAnimationCurve,
-        this.animationDuration = animationDuration,
-        this.barBlur = barBlur,
-        this.blockBackgroundInteraction = blockBackgroundInteraction,
-        this.routeBlur = routeBlur,
-        this.routeColor = routeColor,
-        this.userInputForm = userInputForm,
+        progressIndicatorValueColor = progressIndicatorValueColor,
+        flushbarPosition = flushbarPosition,
+        positionOffset = positionOffset,
+        flushbarStyle = flushbarStyle,
+        forwardAnimationCurve = forwardAnimationCurve,
+        reverseAnimationCurve = reverseAnimationCurve,
+        animationDuration = animationDuration,
+        barBlur = barBlur,
+        blockBackgroundInteraction = blockBackgroundInteraction,
+        routeBlur = routeBlur,
+        routeColor = routeColor,
+        userInputForm = userInputForm,
         super(key: key) {
-    this.onStatusChanged = onStatusChanged ?? (status) {};
+    onStatusChanged = onStatusChanged ?? (status) {};
   }
 
   /// A callback for you to listen to the different Flushbar status
@@ -332,7 +332,7 @@ class _FlushbarState<K extends Object?> extends State<Flushbar<K>>
         widget.userInputForm != null ||
             ((widget.message != null && widget.message!.isNotEmpty) ||
                 widget.messageText != null),
-        "A message is mandatory if you are not using userInputForm. Set either a message or messageText");
+        'A message is mandatory if you are not using userInputForm. Set either a message or messageText');
 
     _isTitlePresent = (widget.title != null || widget.titleText != null);
     _messageTopMargin = _isTitlePresent ? 6.0 : widget.padding.top;
@@ -368,7 +368,7 @@ class _FlushbarState<K extends Object?> extends State<Flushbar<K>>
         final keyContext = _backgroundBoxKey!.currentContext;
 
         if (keyContext != null) {
-          final RenderBox box = keyContext.findRenderObject() as RenderBox;
+          final box = keyContext.findRenderObject() as RenderBox;
           _boxHeightCompleter.complete(box.size);
         }
       },
@@ -493,9 +493,9 @@ class _FlushbarState<K extends Object?> extends State<Flushbar<K>>
         padding: const EdgeInsets.only(
             left: 8.0, right: 8.0, bottom: 8.0, top: 16.0),
         child: FocusScope(
-          child: widget.userInputForm!,
           node: _focusNode,
           autofocus: true,
+          child: widget.userInputForm!,
         ),
       ),
     );
@@ -554,7 +554,7 @@ class _FlushbarState<K extends Object?> extends State<Flushbar<K>>
 
   List<Widget> _getAppropriateRowLayout() {
     double buttonRightPadding;
-    double iconPadding = 0;
+    var iconPadding = 0.0;
     if (widget.padding.right - 12 < 0) {
       buttonRightPadding = 4;
     } else {
@@ -749,10 +749,8 @@ class _FlushbarState<K extends Object?> extends State<Flushbar<K>>
   }
 
   Widget? _getTitleText() {
-    return widget.titleText != null
-        ? widget.titleText
-        : Text(
-            widget.title ?? "",
+    return widget.titleText ?? Text(
+            widget.title ?? '',
             style: TextStyle(
                 fontSize: widget.titleSize ?? 16.0,
                 color: widget.titleColor ?? Colors.white,
@@ -762,7 +760,7 @@ class _FlushbarState<K extends Object?> extends State<Flushbar<K>>
 
   Text _getDefaultNotificationText() {
     return Text(
-      widget.message ?? "",
+      widget.message ?? '',
       style: TextStyle(
           fontSize: widget.messageSize ?? 14.0,
           color: widget.messageColor ?? Colors.white),

--- a/lib/flushbar.dart
+++ b/lib/flushbar.dart
@@ -97,12 +97,13 @@ class Flushbar<T> extends StatefulWidget {
         routeBlur = routeBlur,
         routeColor = routeColor,
         userInputForm = userInputForm,
+        onStatusChanged = onStatusChanged,
         super(key: key) {
     onStatusChanged = onStatusChanged ?? (status) {};
   }
 
   /// A callback for you to listen to the different Flushbar status
-  late final FlushbarStatusCallback? onStatusChanged;
+  final FlushbarStatusCallback? onStatusChanged;
 
   /// The title displayed to the user
   final String? title;

--- a/lib/flushbar.dart
+++ b/lib/flushbar.dart
@@ -84,8 +84,7 @@ class Flushbar<T> extends StatefulWidget {
         dismissDirection = dismissDirection,
         showProgressIndicator = showProgressIndicator,
         progressIndicatorController = progressIndicatorController,
-        progressIndicatorBackgroundColor =
-            progressIndicatorBackgroundColor,
+        progressIndicatorBackgroundColor = progressIndicatorBackgroundColor,
         progressIndicatorValueColor = progressIndicatorValueColor,
         flushbarPosition = flushbarPosition,
         positionOffset = positionOffset,
@@ -749,13 +748,14 @@ class _FlushbarState<K extends Object?> extends State<Flushbar<K>>
   }
 
   Widget? _getTitleText() {
-    return widget.titleText ?? Text(
-            widget.title ?? '',
-            style: TextStyle(
-                fontSize: widget.titleSize ?? 16.0,
-                color: widget.titleColor ?? Colors.white,
-                fontWeight: FontWeight.bold),
-          );
+    return widget.titleText ??
+        Text(
+          widget.title ?? '',
+          style: TextStyle(
+              fontSize: widget.titleSize ?? 16.0,
+              color: widget.titleColor ?? Colors.white,
+              fontWeight: FontWeight.bold),
+        );
   }
 
   Text _getDefaultNotificationText() {

--- a/lib/flushbar_route.dart
+++ b/lib/flushbar_route.dart
@@ -280,17 +280,17 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
     switch (status) {
       case AnimationStatus.completed:
         currentStatus = FlushbarStatus.SHOWING;
-        _onStatusChanged!(currentStatus);
+        if (_onStatusChanged != null) _onStatusChanged!(currentStatus);
         if (overlayEntries.isNotEmpty) overlayEntries.first.opaque = opaque;
 
         break;
       case AnimationStatus.forward:
         currentStatus = FlushbarStatus.IS_APPEARING;
-        _onStatusChanged!(currentStatus);
+        if (_onStatusChanged != null) _onStatusChanged!(currentStatus);
         break;
       case AnimationStatus.reverse:
         currentStatus = FlushbarStatus.IS_HIDING;
-        _onStatusChanged!(currentStatus);
+        if (_onStatusChanged != null) _onStatusChanged!(currentStatus);
         if (overlayEntries.isNotEmpty) overlayEntries.first.opaque = false;
         break;
       case AnimationStatus.dismissed:
@@ -300,7 +300,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
         // back gesture drives this animation to the dismissed status before
         // popping the navigator.
         currentStatus = FlushbarStatus.DISMISSED;
-        _onStatusChanged!(currentStatus);
+        if (_onStatusChanged != null) _onStatusChanged!(currentStatus);
 
         if (!isCurrent) {
           navigator!.finalizeRoute(this);

--- a/lib/flushbar_route.dart
+++ b/lib/flushbar_route.dart
@@ -25,14 +25,14 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
     RouteSettings? settings,
   })  : _builder = Builder(builder: (BuildContext innerContext) {
           return GestureDetector(
-            child: flushbar,
             onTap:
                 flushbar.onTap != null ? () => flushbar.onTap!(flushbar) : null,
+            child: flushbar,
           );
         }),
         _onStatusChanged = flushbar.onStatusChanged,
         super(settings: settings) {
-    _configureAlignment(this.flushbar.flushbarPosition);
+    _configureAlignment(flushbar.flushbarPosition);
   }
 
   void _configureAlignment(FlushbarPosition flushbarPosition) {
@@ -57,7 +57,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
 
   @override
   Iterable<OverlayEntry> createOverlayEntries() {
-    final List<OverlayEntry> overlays = [];
+    final overlays = <OverlayEntry>[];
 
     if (flushbar.blockBackgroundInteraction) {
       overlays.add(
@@ -77,15 +77,15 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
       OverlayEntry(
           builder: (BuildContext context) {
             final Widget annotatedChild = Semantics(
+              focused: false,
+              container: true,
+              explicitChildNodes: true,
               child: AlignTransition(
                 alignment: _animation!,
                 child: flushbar.isDismissible
                     ? _getDismissibleFlushbar(_builder)
                     : _getFlushbar(),
               ),
-              focused: false,
-              container: true,
-              explicitChildNodes: true,
             );
             return annotatedChild;
           },
@@ -150,7 +150,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
   }
 
   /// This string is a workaround until Dismissible supports a returning item
-  String dismissibleKeyGen = "";
+  String dismissibleKeyGen = '';
 
   Widget _getDismissibleFlushbar(Widget child) {
     return Dismissible(
@@ -165,7 +165,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
       },
       key: Key(dismissibleKeyGen),
       onDismissed: (_) {
-        dismissibleKeyGen += "1";
+        dismissibleKeyGen += '1';
         _cancelTimer();
         _wasDismissedBySwipe = true;
 
@@ -346,8 +346,9 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
         '$runtimeType.didReplace called before calling install() or after calling dispose().');
     assert(!_transitionCompleter.isCompleted,
         'Cannot reuse a $runtimeType after disposing it.');
-    if (oldRoute is FlushbarRoute)
+    if (oldRoute is FlushbarRoute) {
       _controller!.value = oldRoute._controller!.value;
+    }
     _animation!.addStatusListener(_handleStatusChanged);
     super.didReplace(oldRoute);
   }
@@ -381,9 +382,9 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
         _timer!.cancel();
       }
       _timer = Timer(flushbar.duration!, () {
-        if (this.isCurrent) {
+        if (isCurrent) {
           navigator!.pop();
-        } else if (this.isActive) {
+        } else if (isActive) {
           navigator!.removeRoute(this);
         }
       });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  pedantic:
+    dependency: "direct main"
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.11.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
+  pedantic: ^1.11.0
   flutter:
     sdk: flutter
     

--- a/test/another_flushbar_test.dart
+++ b/test/another_flushbar_test.dart
@@ -9,9 +9,9 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test('Test Flushbar basic inicialization', () async {
-    final flushbar = new Flushbar(message: "This is a test");
+    final flushbar = Flushbar(message: 'This is a test');
     expect(flushbar.title, null);
-    expect(flushbar.message, "This is a test");
+    expect(flushbar.message, 'This is a test');
     expect(flushbar.duration, null);
     expect(flushbar.backgroundColor, Color(0xFF303030));
     expect(flushbar.flushbarPosition, FlushbarPosition.BOTTOM);


### PR DESCRIPTION
This fixes the following nullpointer when no onStatusChanged has been provided:

```dart
======== Exception caught by animation library =====================================================
The following _CastError was thrown while notifying status listeners for AnimationController:
Null check operator used on a null value

When the exception was thrown, this was the stack: 
#0      FlushbarRoute._handleStatusChanged (package:another_flushbar/flushbar_route.dart:289:25)
#1      AnimationLocalStatusListenersMixin.notifyStatusListeners (package:flutter/src/animation/listener_helpers.dart:199:19)
#2      AnimationController._checkStatusChanged (package:flutter/src/animation/animation_controller.dart:812:7)
#3      AnimationController._startSimulation (package:flutter/src/animation/animation_controller.dart:748:5)
#4      AnimationController._animateToInternal (package:flutter/src/animation/animation_controller.dart:611:12)
...
The AnimationController notifying status listeners was: AnimationController#79f6d(▶ 0.000; for FlushbarRoute<dynamic>)
====================================================================================================
```

This merge request also adds pedantic, and formats all the files accordingly.