### PR TITLE
fix (#38): only tap dismisses flushbar

### DIFF
--- a/lib/flushbar_route.dart
+++ b/lib/flushbar_route.dart
@@ -72,8 +72,9 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
       overlays.add(
         OverlayEntry(
             builder: (BuildContext context) {
-              return GestureDetector(
-                onTap: flushbar.isDismissible ? () => flushbar.dismiss() : null,
+              return Listener(
+                onPointerDown:
+                    flushbar.isDismissible ? (_) => flushbar.dismiss() : null,
                 child: _createBackgroundOverlay(),
               );
             },


### PR DESCRIPTION
Now any pointer down event dismisses flushbar in case of blockBackgroundInteraction

this solves #38 as any gesture is started by a pointerDownEvent