### PR TITLE
Fix type 'Null' is not a subtype of type 'FutureOr<bool>'

### DIFF
--- a/lib/flushbar_route.dart
+++ b/lib/flushbar_route.dart
@@ -25,8 +25,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
     RouteSettings? settings,
   })  : _builder = Builder(builder: (BuildContext innerContext) {
           return GestureDetector(
-            onTap:
-                flushbar.onTap != null ? () => flushbar.onTap!(flushbar) : null,
+            onTap: flushbar.onTap != null ? () => flushbar.onTap!(flushbar) : null,
             child: flushbar,
           );
         }),
@@ -40,13 +39,15 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
       case FlushbarPosition.TOP:
         {
           _initialAlignment = Alignment(-1.0, -2.0);
-          _endAlignment = flushbar.endOffset != null ? Alignment(-1.0, -1.0) + Alignment(flushbar.endOffset!.dx, flushbar.endOffset!.dy) : Alignment(-1.0, -1.0);
+          _endAlignment =
+              flushbar.endOffset != null ? Alignment(-1.0, -1.0) + Alignment(flushbar.endOffset!.dx, flushbar.endOffset!.dy) : Alignment(-1.0, -1.0);
           break;
         }
       case FlushbarPosition.BOTTOM:
         {
           _initialAlignment = Alignment(-1.0, 2.0);
-          _endAlignment = flushbar.endOffset != null ? Alignment(-1.0, 1.0) + Alignment(flushbar.endOffset!.dx, flushbar.endOffset!.dy) : Alignment(-1.0, 1.0);
+          _endAlignment =
+              flushbar.endOffset != null ? Alignment(-1.0, 1.0) + Alignment(flushbar.endOffset!.dx, flushbar.endOffset!.dy) : Alignment(-1.0, 1.0);
           break;
         }
     }
@@ -63,7 +64,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
 
     return Future.value(RoutePopDisposition.pop);
   }
-  
+
   @override
   Iterable<OverlayEntry> createOverlayEntries() {
     final overlays = <OverlayEntry>[];
@@ -91,9 +92,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
               explicitChildNodes: true,
               child: AlignTransition(
                 alignment: _animation!,
-                child: flushbar.isDismissible
-                    ? _getDismissibleFlushbar(_builder)
-                    : _getFlushbar(),
+                child: flushbar.isDismissible ? _getDismissibleFlushbar(_builder) : _getFlushbar(),
               ),
             );
             return annotatedChild;
@@ -111,9 +110,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
         animation: _filterBlurAnimation!,
         builder: (context, child) {
           return BackdropFilter(
-            filter: ImageFilter.blur(
-                sigmaX: _filterBlurAnimation!.value,
-                sigmaY: _filterBlurAnimation!.value),
+            filter: ImageFilter.blur(sigmaX: _filterBlurAnimation!.value, sigmaY: _filterBlurAnimation!.value),
             child: Container(
               constraints: BoxConstraints.expand(),
               color: _filterColorAnimation!.value,
@@ -128,9 +125,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
         animation: _filterBlurAnimation!,
         builder: (context, child) {
           return BackdropFilter(
-            filter: ImageFilter.blur(
-                sigmaX: _filterBlurAnimation!.value,
-                sigmaY: _filterBlurAnimation!.value),
+            filter: ImageFilter.blur(sigmaX: _filterBlurAnimation!.value, sigmaY: _filterBlurAnimation!.value),
             child: Container(
               constraints: BoxConstraints.expand(),
               color: Colors.transparent,
@@ -166,8 +161,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
       direction: _getDismissDirection(),
       resizeDuration: null,
       confirmDismiss: (_) {
-        if (currentStatus == FlushbarStatus.IS_APPEARING ||
-            currentStatus == FlushbarStatus.IS_HIDING) {
+        if (currentStatus == FlushbarStatus.IS_APPEARING || currentStatus == FlushbarStatus.IS_HIDING) {
           return Future.value(false);
         }
         return Future.value(true);
@@ -208,8 +202,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
   }
 
   @override
-  bool get finishedWhenPopped =>
-      _controller!.status == AnimationStatus.dismissed;
+  bool get finishedWhenPopped => _controller!.status == AnimationStatus.dismissed;
 
   /// The animation that drives the route's transition and the previous route's
   /// forward transition.
@@ -227,8 +220,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
   /// this route from the previous one, and back to the previous route from this
   /// one.
   AnimationController createAnimationController() {
-    assert(!_transitionCompleter.isCompleted,
-        'Cannot reuse a $runtimeType after disposing it.');
+    assert(!_transitionCompleter.isCompleted, 'Cannot reuse a $runtimeType after disposing it.');
     assert(flushbar.animationDuration >= Duration.zero);
     return AnimationController(
       duration: flushbar.animationDuration,
@@ -241,8 +233,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
   /// the transition controlled by the animation controller created by
   /// [createAnimationController()].
   Animation<Alignment> createAnimation() {
-    assert(!_transitionCompleter.isCompleted,
-        'Cannot reuse a $runtimeType after disposing it.');
+    assert(!_transitionCompleter.isCompleted, 'Cannot reuse a $runtimeType after disposing it.');
     assert(_controller != null);
     return AlignmentTween(begin: _initialAlignment, end: _endAlignment).animate(
       CurvedAnimation(
@@ -271,8 +262,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
   Animation<Color?>? createColorFilterAnimation() {
     if (flushbar.routeColor == null) return null;
 
-    return ColorTween(begin: Colors.transparent, end: flushbar.routeColor)
-        .animate(
+    return ColorTween(begin: Colors.transparent, end: flushbar.routeColor).animate(
       CurvedAnimation(
         parent: _controller!,
         curve: Interval(
@@ -325,11 +315,9 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
 
   @override
   void install() {
-    assert(!_transitionCompleter.isCompleted,
-        'Cannot install a $runtimeType after disposing it.');
+    assert(!_transitionCompleter.isCompleted, 'Cannot install a $runtimeType after disposing it.');
     _controller = createAnimationController();
-    assert(_controller != null,
-        '$runtimeType.createAnimationController() returned null.');
+    assert(_controller != null, '$runtimeType.createAnimationController() returned null.');
     _filterBlurAnimation = createBlurFilterAnimation();
     _filterColorAnimation = createColorFilterAnimation();
     _animation = createAnimation();
@@ -339,10 +327,8 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
 
   @override
   TickerFuture didPush() {
-    assert(_controller != null,
-        '$runtimeType.didPush called before calling install() or after calling dispose().');
-    assert(!_transitionCompleter.isCompleted,
-        'Cannot reuse a $runtimeType after disposing it.');
+    assert(_controller != null, '$runtimeType.didPush called before calling install() or after calling dispose().');
+    assert(!_transitionCompleter.isCompleted, 'Cannot reuse a $runtimeType after disposing it.');
     _animation!.addStatusListener(_handleStatusChanged);
     _configureTimer();
     super.didPush();
@@ -351,10 +337,8 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
 
   @override
   void didReplace(Route<dynamic>? oldRoute) {
-    assert(_controller != null,
-        '$runtimeType.didReplace called before calling install() or after calling dispose().');
-    assert(!_transitionCompleter.isCompleted,
-        'Cannot reuse a $runtimeType after disposing it.');
+    assert(_controller != null, '$runtimeType.didReplace called before calling install() or after calling dispose().');
+    assert(!_transitionCompleter.isCompleted, 'Cannot reuse a $runtimeType after disposing it.');
     if (oldRoute is FlushbarRoute) {
       _controller!.value = oldRoute._controller!.value;
     }
@@ -364,10 +348,8 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
 
   @override
   bool didPop(T? result) {
-    assert(_controller != null,
-        '$runtimeType.didPop called before calling install() or after calling dispose().');
-    assert(!_transitionCompleter.isCompleted,
-        'Cannot reuse a $runtimeType after disposing it.');
+    assert(_controller != null, '$runtimeType.didPop called before calling install() or after calling dispose().');
+    assert(!_transitionCompleter.isCompleted, 'Cannot reuse a $runtimeType after disposing it.');
 
     _result = result;
     _cancelTimer();
@@ -424,10 +406,12 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
 
   @override
   void dispose() {
-    assert(!_transitionCompleter.isCompleted,
-        'Cannot dispose a $runtimeType twice.');
+    assert(!_transitionCompleter.isCompleted, 'Cannot dispose a $runtimeType twice.');
     _controller?.dispose();
-    _transitionCompleter.complete(_result);
+    if (_result != null) {
+      _transitionCompleter.complete(_result);
+    }
+
     super.dispose();
   }
 
@@ -438,8 +422,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
   String toString() => '$runtimeType(animation: $_controller)';
 }
 
-FlushbarRoute showFlushbar<T>(
-    {required BuildContext context, required Flushbar flushbar}) {
+FlushbarRoute showFlushbar<T>({required BuildContext context, required Flushbar flushbar}) {
   return FlushbarRoute<T>(
     flushbar: flushbar,
     settings: RouteSettings(name: FLUSHBAR_ROUTE_NAME),


### PR DESCRIPTION
Hello,

I would like to submit a fix for the bug when disposing Flusbar

```
══╡ EXCEPTION CAUGHT BY FOUNDATION LIBRARY ╞════════════════════════════════════════════════════════
The following _TypeError was thrown while dispatching notifications for OverlayEntry:
type 'Null' is not a subtype of type 'FutureOr<bool>'

When the exception was thrown, this was the stack:
#1      FlushbarRoute.dispose (package:another_flushbar/flushbar_route.dart:430:26)
#2      _RouteEntry.dispose.<anonymous closure> (package:flutter/src/widgets/navigator.dart:3165:19)
#3      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:308:24)
#4      OverlayEntry._updateMounted (package:flutter/src/widgets/overlay.dart:130:5)
#5      _OverlayEntryWidgetState.dispose (package:flutter/src/widgets/overlay.dart:200:18)
#6      StatefulElement.unmount (package:flutter/src/widgets/framework.dart:4895:11)
#7      _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:1883:13)
#8      ListIterable.forEach (dart:_internal/iterable.dart:39:13)
#9      _InactiveElements._unmountAll (package:flutter/src/widgets/framework.dart:1892:25)
#10     BuildOwner.finalizeTree.<anonymous closure> (package:flutter/src/widgets/framework.dart:2879:27)
#11     BuildOwner.lockState (package:flutter/src/widgets/framework.dart:2510:15)
#12     BuildOwner.finalizeTree (package:flutter/src/widgets/framework.dart:2878:7)
#13     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:884:19)
#14     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1143:15)
#15     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1080:9)
(elided 4 frames from dart:async)

The OverlayEntry sending notification was:
  OverlayEntry#ed597(opaque: false; maintainState: false)
════════════════════════════════════════════════════════════════════════════════════════════════════
```

Thanks for keeping Flushbar alive.
