### PR TITLE
prevent warnings

### DIFF
--- a/lib/flushbar.dart
+++ b/lib/flushbar.dart
@@ -347,7 +347,7 @@ class _FlushbarState<K extends Object?> extends State<Flushbar<K>>
   }
 
   void _configureLeftBarFuture() {
-    SchedulerBinding.instance!.addPostFrameCallback(
+    SchedulerBinding.instance.addPostFrameCallback(
       (_) {
         final keyContext = _backgroundBoxKey!.currentContext;
 


### PR DESCRIPTION
Warning: Operand of null-aware operation '!' has type 'SchedulerBinding' which excludes null.
 - 'SchedulerBinding' is from 'package:flutter/src/scheduler/binding.dart' ('/C:/tools/flutter/packages/flutter/lib/src/scheduler/binding.dart').
    SchedulerBinding.instance!.addPostFrameCallback(