### PR TITLE
fix for null safety schedulerbinding

### DIFF
--- a/lib/flushbar.dart
+++ b/lib/flushbar.dart
@@ -347,7 +347,7 @@ class _FlushbarState<K extends Object?> extends State<Flushbar<K>>
   }
 
   void _configureLeftBarFuture() {
-    SchedulerBinding.instance.addPostFrameCallback(
+    SchedulerBinding.instance!.addPostFrameCallback(
       (_) {
         final keyContext = _backgroundBoxKey!.currentContext;
 


### PR DESCRIPTION
This issue error because your forgot add null safety at "addPostFrameCallback"

Error: Method 'addPostFrameCallback' cannot be called on 'SchedulerBinding?' because it is potentially null.
 - 'SchedulerBinding' is from 'package:flutter/src/scheduler/binding.dart' ('/C:/flutter/packages/flutter/lib/src/scheduler/binding.dart').
    SchedulerBinding.instance.addPostFrameCallback(

Im Already Done solve it, just add  null safety inside instance