### PR TITLE
feature/handle-click-behind-old-safearea

### DIFF
--- a/lib/flushbar.dart
+++ b/lib/flushbar.dart
@@ -18,6 +18,7 @@ class Flushbar<T> extends StatefulWidget {
   Flushbar(
       {Key? key,
       this.title,
+      this.safeArea = true,
       this.titleColor,
       this.titleSize,
       this.message,
@@ -221,6 +222,10 @@ class Flushbar<T> extends StatefulWidget {
   /// Intended to replace [margin] when you need items below Flushbar to be accessible
   final Offset? endOffset;
 
+  /// Choose if the flushbar must be displayed inside a safeArea
+  /// For custom safeArea you can use margin instead
+  final bool safeArea;
+
   route.FlushbarRoute<T?>? flushbarRoute;
 
   /// Show the flushbar. Kicks in [FlushbarStatus.IS_APPEARING] state followed by [FlushbarStatus.SHOWING]
@@ -398,18 +403,8 @@ class _FlushbarState<K extends Object?> extends State<Flushbar<K>>
         color: widget.flushbarStyle == FlushbarStyle.FLOATING
             ? Colors.transparent
             : widget.backgroundColor,
-        child: SafeArea(
-          minimum: widget.flushbarPosition == FlushbarPosition.BOTTOM
-              ? EdgeInsets.only(
-                  bottom: MediaQuery.of(context).viewInsets.bottom +
-                      widget.positionOffset)
-              : EdgeInsets.only(
-                  top: MediaQuery.of(context).viewInsets.top +
-                      widget.positionOffset),
-          bottom: widget.flushbarPosition == FlushbarPosition.BOTTOM,
-          top: widget.flushbarPosition == FlushbarPosition.TOP,
-          left: false,
-          right: false,
+        child: GestureDetector(
+          onTap: () => widget.onTap?.call(widget),
           child: _getFlushbar(),
         ),
       ),

--- a/lib/flushbar_route.dart
+++ b/lib/flushbar_route.dart
@@ -23,13 +23,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
   FlushbarRoute({
     required this.flushbar,
     RouteSettings? settings,
-  })  : _builder = Builder(builder: (BuildContext innerContext) {
-          return GestureDetector(
-            onTap:
-                flushbar.onTap != null ? () => flushbar.onTap!(flushbar) : null,
-            child: flushbar,
-          );
-        }),
+  })  : _builder = Builder(builder: (BuildContext innerContext) => flushbar),
         _onStatusChanged = flushbar.onStatusChanged,
         super(settings: settings) {
     _configureAlignment(flushbar.flushbarPosition);
@@ -89,6 +83,14 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
       );
     }
 
+    Widget child =  flushbar.isDismissible
+        ? _getDismissibleFlushbar(_builder)
+        : _getFlushbar();
+
+    if (flushbar.safeArea) {
+      child = SafeArea(child: child);
+    }
+
     overlays.add(
       OverlayEntry(
           builder: (BuildContext context) {
@@ -98,9 +100,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
               explicitChildNodes: true,
               child: AlignTransition(
                 alignment: _animation!,
-                child: flushbar.isDismissible
-                    ? _getDismissibleFlushbar(_builder)
-                    : _getFlushbar(),
+                child: child,
               ),
             );
             return annotatedChild;


### PR DESCRIPTION
This PR aim to fix a use case where a top floating flushbar didn't allow user to click on appbar elements.

For example the following screen, you can see a rectangle with red line (which have added). It's coming from the old safeArea. Because of it, it's not possible to click on the bottom of my Icons.home.

<img width="396" alt="Capture d’écran 2022-10-26 à 17 00 29" src="https://user-images.githubusercontent.com/37028599/198062637-01b605df-fe0a-4828-974e-6bf447fece4e.png">

With the new system, the safeArea didn't interact with user click which let the user to interact with the background.
<img width="371" alt="Capture d’écran 2022-10-26 à 17 00 14" src="https://user-images.githubusercontent.com/37028599/198062138-f1ede5cc-da9b-419e-86f4-0d9bf16ab78f.png">

Code used to test.

```dart
import 'package:another_flushbar/flushbar.dart';
import 'package:flutter/material.dart';

void main() {
  runApp(
    const MaterialApp(
      home: Home(),
    ),
  );
}

class Home extends StatelessWidget {
  const Home({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        leading: IconButton(
          icon: const Icon(Icons.home),
          onPressed: () {
            print("Home button tapped");
          },
        ),
      ),
      body: Center(
        child: OutlinedButton(
          onPressed: () {
            Flushbar<void>? flush;
            flush = Flushbar<void>(
              borderRadius: const BorderRadius.all(Radius.circular(8.0)),
              reverseAnimationCurve: Curves.decelerate,
              margin: const EdgeInsets.only(
                left: 12,
                right: 12,
                top: kToolbarHeight + 9,
              ),
              padding: const EdgeInsets.symmetric(horizontal: 12),
              messageText: Container(
                key: const ValueKey<String>("message_delete_success"),
                width: double.infinity,
                alignment: Alignment.center,
                child: Row(
                  children: <Widget>[
                    const Expanded(
                      child: Text("THE FLUSHBAR"),
                    ),
                    IconButton(
                      onPressed: () => flush?.dismiss(),
                      icon: const Icon(Icons.close, color: Colors.white),
                    ),
                  ],
                ),
              ),
              isDismissible: false,
              backgroundColor: Colors.orange,
              flushbarPosition: FlushbarPosition.TOP,
              flushbarStyle: FlushbarStyle.FLOATING,
            );

            flush.show(context);
          },
          child: const Text("SHOW FLUSHBAR"),
        ),
      ),
    );
  }
}

```
