### PR TITLE
Makes transition completer type nullable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 build/
 
 .idea/
+
+android/loca
+

--- a/lib/flushbar_route.dart
+++ b/lib/flushbar_route.dart
@@ -8,7 +8,7 @@ import 'flushbar.dart';
 class FlushbarRoute<T> extends OverlayRoute<T> {
   final Flushbar flushbar;
   final Builder _builder;
-  final Completer<T> _transitionCompleter = Completer<T>();
+  final Completer<T?> _transitionCompleter = Completer<T?>();
   final FlushbarStatusCallback? _onStatusChanged;
 
   Animation<double>? _filterBlurAnimation;
@@ -52,7 +52,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
     }
   }
 
-  Future<T> get completed => _transitionCompleter.future;
+  Future<T?> get completed => _transitionCompleter.future;
   bool get opaque => false;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
     
 dev_dependencies:
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
This PR fixes the following error:

When I try to show the flushbar before popping to another route, I get the exception:

```
_TypeError (type 'Null' is not a subtype of type 'FutureOr<String>')
```
 
 This occurs in the dispose method in the FlushbarRoute.  At that point, I'm trying to dispose of a flushbar of type `<String>`, but `_result` is null:
 
 ```dart
   @override
  void dispose() {
    assert(!_transitionCompleter.isCompleted,
        'Cannot dispose a $runtimeType twice.');
    _controller?.dispose();
    _transitionCompleter.complete(_result);
    super.dispose();
  }
 ```