### PR TITLE
Fixing type 'Null' is not a subtype of type 'FutureOr<Text>' 

### DIFF
--- a/lib/flushbar_route.dart
+++ b/lib/flushbar_route.dart
@@ -434,7 +434,9 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
     assert(!_transitionCompleter.isCompleted,
         'Cannot dispose a $runtimeType twice.');
     _controller?.dispose();
-    _transitionCompleter.complete(_result);
+    if (_result != null) {
+      _transitionCompleter.complete(_result);
+    }
     super.dispose();
   }
 


### PR DESCRIPTION
Not calling the completer when flushbar is disposed if the result is null