### PR TITLE
Update flushbar_route.dart: When using duration + isDismissible at fa…

### DIFF
--- a/lib/flushbar_route.dart
+++ b/lib/flushbar_route.dart
@@ -63,7 +63,9 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
 
   @override
   Future<RoutePopDisposition> willPop() {
-    if (!flushbar.isDismissible) {
+    if (!flushbar.isDismissible &&
+        ((flushbar.duration == null) ||
+            (flushbar.duration != null && _timer?.isActive == true))) {
       return Future.value(RoutePopDisposition.doNotPop);
     }
 


### PR DESCRIPTION
When using duration + isDismissible at false, flushbar is not popped at the end of the timer because willPop have a logic which prevent any pop when isDismissible is false. 
Timer callback call maybePop which call willPop to check if pop is possible.