### PR TITLE
Delete unused field positionOffset

### DIFF
--- a/lib/flushbar.dart
+++ b/lib/flushbar.dart
@@ -49,7 +49,6 @@ class Flushbar<T> extends StatefulWidget {
       this.progressIndicatorBackgroundColor,
       this.progressIndicatorValueColor,
       this.flushbarPosition = FlushbarPosition.BOTTOM,
-      this.positionOffset = 0.0,
       this.flushbarStyle = FlushbarStyle.FLOATING,
       this.forwardAnimationCurve = Curves.easeOutCirc,
       this.reverseAnimationCurve = Curves.easeOutCirc,
@@ -174,8 +173,6 @@ class Flushbar<T> extends StatefulWidget {
   /// Flushbar can be based on [FlushbarPosition.TOP] or on [FlushbarPosition.BOTTOM] of your screen.
   /// [FlushbarPosition.BOTTOM] is the default.
   final FlushbarPosition flushbarPosition;
-
-  final double positionOffset;
 
   /// [FlushbarDismissDirection.VERTICAL] by default.
   /// Can also be [FlushbarDismissDirection.HORIZONTAL] in which case both left and right dismiss are allowed.


### PR DESCRIPTION
The **positionOffset** field isn't used in any widget or method in Flushbar but exist in constructor. 
I deleted this field in PR